### PR TITLE
New compile and link flags for enabling benchmarks

### DIFF
--- a/jigsaw.cfg
+++ b/jigsaw.cfg
@@ -54,7 +54,7 @@
 %if %{bits} == 64
 %   define model        -m64
 %elif %{bits} == 32
-%   define model        -m32
+%   define model        --target=wasm32-wasi
 %else
 %   error Please define number of bits - see instructions in config file
 %endif
@@ -119,12 +119,12 @@ default:
 #      path.  You can adjust it, or add lines for other environment variables. 
 #      See: https://www.spec.org/cpu2017/Docs/config.html#preenv
 #      and: https://gcc.gnu.org/onlinedocs/gcc/Environment-Variables.html
-   preENV_LD_LIBRARY_PATH  = %{gcc_dir}/lib64/:%{gcc_dir}/lib/:/lib64
+   preENV_LD_LIBRARY_PATH  = /home/eymen/Documents/jit_hw/wasi-sdk/build/toolchain/llvm-build-prefix/src/llvm-build-build/lib:%{gcc_dir}/lib64/:%{gcc_dir}/lib/:/lib64
   #preENV_LD_LIBRARY_PATH  = %{gcc_dir}/lib64/:%{gcc_dir}/lib/:/lib64:%{ENV_LD_LIBRARY_PATH}
    SPECLANG                = %{gcc_dir}/bin/
-   CC                      = /opt/wasi-sdk/bin/clang     -std=c99   %{model}
-   CXX                     = /opt/wasi-sdk/bin/clang++              %{model}
-   FC                      = $(SPECLANG)gfortran      %{model}
+   CC                      = /home/eymen/Documents/jit_hw/wasi-sdk/build/install/bin/clang     -std=c99   %{model}
+   CXX                     = /home/eymen/Documents/jit_hw/wasi-sdk/build/install/bin/clang++    -std=c++11  %{model}
+   FC                      = /home/eymen/Documents/jit_hw/wasi-sdk/build/install/bin/flang      %{model}
    # How to say "Show me your version, please"
    CC_VERSION_OPTION       = -v
    CXX_VERSION_OPTION      = -v
@@ -159,21 +159,55 @@ default:               # data model applies to all benchmarks
 %else
 %   define suffix X64
 %endif
-   PORTABILITY    = -DSPEC_%{os}_%{suffix}
+   PORTABILITY    = -DSPEC_%{os}_%{suffix} -fno-exceptions -mllvm -wasm-enable-sjlj -DSPEC_NO_I_SYS_WAIT -DDONT_DECLARE_STD -D_WASI_EMULATED_SIGNAL -Wno-implicit-function-declaration -DNO_ENVIRON_ARRAY
+
+502.gcc_r:
+   PORTABILITY = -DSPEC_NO_I_SYS_WAIT -UHAVE_SYS_WAIT_H
+
+510.parest_r:
+   PORTABILITY   = -D_WASI_EMULATED_PROCESS_CLOCKS -std=c++03 -D_WASI_EMULATED_SIGNAL -Wl,--allow-undefined
+
+511.povray_r:
+   PORTABILITY   = -mllvm -wasm-enable-sjlj -Wl,--allow-undefined
+
+520.omnetpp_r,620.omnetpp_s:  #lang='CXX'
+   PORTABILITY   = -D_WASI_EMULATED_SIGNAL -lwasi-emulated-signal -D_WASI_EMULATED_PTHREAD -lwasi-emulated-pthread -mllvm -wasm-enable-sjlj -Wl,--allow-undefined 
 
 521.wrf_r,621.wrf_s:  #lang='F,C'
-   CPORTABILITY  = -DSPEC_CASE_FLAG 
-   FPORTABILITY  = -fconvert=big-endian
+   CPORTABILITY  = -DSPEC_CASE_FLAG -Wno-implicit-function-declaration -D_WASI_EMULATED_PROCESS_CLOCKS -Wno-error -Wno-int-conversion -fpermissive
+   FPORTABILITY  = -fno-automatic -fno-backslash
 
 523.xalancbmk_r,623.xalancbmk_s:  #lang='CXX'
-   PORTABILITY   = -DSPEC_%{os}
+   PORTABILITY   = -DSPEC_LINUX -D__linux__
 
-526.blender_r:  #lang='CXX,C'
-   PORTABILITY   = -funsigned-char -DSPEC_LINUX
+525.x264_r,625.x264_s:  #lang='C'
+   PORTABILITY = -D_WASI_EMULATED_SIGNAL -include string.h
+   EXTRA_LDFLAGS = -Wl,--allow-multiple-definition -lwasi-emulated-signal
+
+#FAIL Requires <sys/wait.h>
+526.blender_r:
+   PORTABILITY = -D_WASI_EMULATED_SIGNAL -lwasi-emulated-signal -Wno-implicit-function-declaration -D_WASI_EMULATED_PROCESS_CLOCKS -lwasi-emulated-process-clocks
+
 
 527.cam4_r,627.cam4_s:  #lang='F,C'
-   PORTABILITY   = -DSPEC_CASE_FLAG
+   CPORTABILITY   = -D_WASI_EMULATED_PROCESS_CLOCKS -Wno-error -Wno-implicit-int
 
+531.deepsjeng_r,631.deepsjeng_s:
+   PORTABILITY = -D_WASI_EMULATED_SIGNAL -lwasi-emulated-signal
+
+#FAIL Requires <sys/wait.h>
+538.imagick_r:
+  PORTABILITY = -D_WASI_EMULATED_SIGNAL -UMAGICKCORE_POSIX_SUPPORT
+
+541.leela_r,641.leela_s:
+  PORTABILITY = -Wl,--allow-undefined
+
+# Compiles but this is not a robust solution. A thread_local variable conflict is removed by renaming a variable.
+544.nab_r,644.nab_s:
+ PORTABILITY =  -D'errno=__errno_alias'
+
+#FAIL Flang error, possibly needs flang-rt
+#549.fotonik3d_r:
 628.pop2_s:  #lang='F,C'
    CPORTABILITY    = -DSPEC_CASE_FLAG
    FPORTABILITY    = -fconvert=big-endian
@@ -192,7 +226,6 @@ default:               # data model applies to all benchmarks
    #
    #     runcpu --define bits=64
    #
-   fail_build = 1
 %else
    intspeed,fpspeed:
       EXTRA_OPTIMIZE = -fopenmp -DSPEC_OPENMP
@@ -211,7 +244,10 @@ default:               # data model applies to all benchmarks
 #                   switches here.  See also 'About the -fno switches' below.
 #
 default=base:         # flags for all base 
-   OPTIMIZE       = -g -O3 --sysroot=/opt/wasi-sdk/share/wasi-sysroot -fno-unsafe-math-optimizations  -fno-tree-vectorize
+   OPTIMIZE       = -g -O3 --sysroot=/home/eymen/Documents/jit_hw/wasi-sdk/build/install/share/wasi-sysroot
+   FOPTIMIZE       = -g -O3 --sysroot=/home/eymen/Documents/jit_hw/wasi-sdk/build/install/share/wasi-sysroot
+   COPTIMIZE       = -g -O3 --sysroot=/home/eymen/Documents/jit_hw/wasi-sdk/build/install/share/wasi-sysroot -fno-unsafe-math-optimizations  -fno-tree-vectorize
+   CXXOPTIMIZE       = -g -O3 --sysroot=/home/eymen/Documents/jit_hw/wasi-sdk/build/install/share/wasi-sysroot -fno-unsafe-math-optimizations  -fno-tree-vectorize
 
 intrate,intspeed=base: # flags for integer base
 %if %{bits} == 32                    


### PR DESCRIPTION
With the current config 13 over 23 benchmarks are getting compiled. For additional benchmarks `<sys/wait.h>` header can be fixed.